### PR TITLE
hotfix: reorder video sources

### DIFF
--- a/src/containers/Home/HeroAssetContainer.tsx
+++ b/src/containers/Home/HeroAssetContainer.tsx
@@ -6,8 +6,8 @@ export const HeroAssetContainer: React.FC = () => {
   return (
     <Container>
       <Video autoPlay loop muted playsInline poster={'/videos/poster.jpeg'}>
-        <source src={'/videos/output.webm'} type={'video/webm'} />
         <source src={'/videos/output.mp4'} type={'video/mp4'} />
+        <source src={'/videos/output.webm'} type={'video/webm'} />
         <source src={'/videos/output.ogv'} type={'video/ogv'} />
       </Video>
     </Container>


### PR DESCRIPTION
### Description:

Website crashes on iOS (18.3.1, iPhone 13) in Safari.

1. Visit https://free.technology
2. Wait until loading is finished

![image](https://github.com/user-attachments/assets/def07f6c-0d4a-484c-8e25-babc3ee031ea)

### Related Issue(s):
[Link to the related Issue(s), if any.]

### Changes Included:
- [x] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
[Explain any new decisions made during the implementation of the changes.]

### Testing:
[Describe how the changes have been tested.]

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules