### PR TITLE
Use multi-stage build to fix TypeScript 6.0 build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY . .
-
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
+
+COPY . .
 RUN yarn build
 
 FROM node:22-alpine AS runner
@@ -20,9 +21,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/yarn.lock ./yarn.lock
-COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/next.config.js ./next.config.js
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --production
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM node:20-alpine
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN yarn install --frozen-lockfile
+RUN yarn build
+
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 
@@ -9,9 +18,11 @@ EXPOSE ${PORT}
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-COPY . .
-
-RUN yarn install --production
-RUN yarn build
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/next.config.js ./next.config.js
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Fix Jenkins Docker build failure caused by `yarn install --production` skipping devDependencies